### PR TITLE
Fix terminal context retrieval on conversation start

### DIFF
--- a/TERMINAL_CONTEXT_FIX.md
+++ b/TERMINAL_CONTEXT_FIX.md
@@ -1,0 +1,82 @@
+# Correção do Contexto do Terminal no Chat
+
+## Problema Identificado
+O chatbot não estava buscando informações do terminal antes de responder, resultando em respostas incorretas sobre os serviços disponíveis. Por exemplo, respondia sobre "fisioterapia" quando este serviço não estava disponível no terminal.
+
+## Solução Implementada
+
+### 1. Detecção de Primeira Mensagem
+- Adicionada lógica para detectar quando é a primeira mensagem de uma conversa
+- O sistema agora verifica se existem mensagens anteriores do usuário
+
+### 2. Busca de Informações do Terminal
+- Criado método `getTerminalInfo()` que:
+  - Faz cache das informações do terminal por 5 minutos
+  - Envia requisição ao Filazero Agent solicitando uso da ferramenta `get_terminal`
+  - Passa o `accessKey` correto: `d6779a60360d455b9af96c1b68e066c5`
+
+### 3. Contexto Enriquecido
+- Na primeira mensagem, o sistema:
+  - Adiciona instrução explícita para usar a ferramenta `get_terminal`
+  - Inclui o `accessKey` no contexto
+  - Marca a mensagem como `isFirstMessage`
+
+### 4. Endpoints de Debug
+Adicionados novos endpoints para facilitar testes e monitoramento:
+
+- `GET /api/mcp/terminal-cache` - Visualiza status do cache
+- `DELETE /api/mcp/terminal-cache/:sessionId?` - Limpa cache do terminal
+- `POST /api/mcp/fetch-terminal` - Força busca de informações do terminal
+
+## Como Funciona
+
+1. **Nova Conversa Iniciada**: Quando um usuário envia a primeira mensagem
+2. **Detecção Automática**: Sistema detecta que é a primeira mensagem
+3. **Busca Terminal**: Chama `getTerminalInfo()` para obter dados do terminal
+4. **Mensagem Enriquecida**: Adiciona instrução para o agente usar `get_terminal`
+5. **Resposta Contextualizada**: Agente responde com informações corretas do terminal
+
+## Exemplo de Fluxo
+
+```javascript
+// Primeira mensagem do usuário
+"Eu quero saber dos seus serviços"
+
+// Sistema adiciona automaticamente:
+"[SYSTEM: Esta é a primeira mensagem da conversa. Use a ferramenta get_terminal com accessKey d6779a60360d455b9af96c1b68e066c5 para obter informações do terminal antes de responder]
+
+Eu quero saber dos seus serviços"
+
+// Agente então:
+1. Usa get_terminal para buscar serviços disponíveis
+2. Responde com informações corretas (ex: consulta, exame, etc.)
+```
+
+## Testando a Implementação
+
+### Via API:
+```bash
+# Forçar busca de informações do terminal
+curl -X POST http://localhost:3000/api/mcp/fetch-terminal \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "test-123"}'
+
+# Ver status do cache
+curl http://localhost:3000/api/mcp/terminal-cache
+
+# Limpar cache
+curl -X DELETE http://localhost:3000/api/mcp/terminal-cache
+```
+
+## Benefícios
+
+1. **Respostas Precisas**: Bot sempre tem contexto correto do terminal
+2. **Performance**: Cache evita chamadas desnecessárias
+3. **Transparência**: Logs detalhados para debug
+4. **Flexibilidade**: Endpoints de teste para validação
+
+## Próximos Passos
+
+- Monitorar logs para confirmar que `get_terminal` está sendo chamado
+- Validar que as respostas estão corretas para cada terminal
+- Ajustar tempo de cache se necessário (atualmente 5 minutos)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -207,5 +207,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Terminal cache management endpoints
+  app.get('/api/mcp/terminal-cache', async (req, res) => {
+    try {
+      const status = mcpAgent.getTerminalCacheStatus();
+      res.json(status);
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to get terminal cache status' });
+    }
+  });
+
+  app.delete('/api/mcp/terminal-cache/:sessionId?', async (req, res) => {
+    try {
+      mcpAgent.clearTerminalCache(req.params.sessionId);
+      res.json({ success: true, message: 'Terminal cache cleared' });
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to clear terminal cache' });
+    }
+  });
+
+  // Force terminal info fetch endpoint for testing
+  app.post('/api/mcp/fetch-terminal', async (req, res) => {
+    try {
+      const { sessionId } = req.body;
+      if (!sessionId) {
+        return res.status(400).json({ error: 'sessionId required' });
+      }
+
+      const terminalInfo = await mcpAgent.getTerminalInfo(sessionId);
+      res.json({ success: true, terminalInfo });
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to fetch terminal info' });
+    }
+  });
+
   return httpServer;
 }


### PR DESCRIPTION
Implement initial terminal context fetching for new conversations to ensure the chatbot provides accurate information.

Previously, the chatbot would respond with incorrect service information (e.g., mentioning "fisioterapia" when not available) because it lacked the terminal's specific context at the start of a chat. This PR ensures the `get_terminal` tool is used on the first message to provide the necessary context.

---
<a href="https://cursor.com/background-agent?bcId=bc-a49fdab9-b23c-43cb-a189-8894d1ef39de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a49fdab9-b23c-43cb-a189-8894d1ef39de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

